### PR TITLE
feat: add server dropdown to Swagger UI and GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,73 @@
+name: Deploy Documentation to GitHub Pages
+
+on:
+  workflow_dispatch:  # Manual trigger
+  push:
+    branches:
+      - main
+    paths:
+      - 'schemas/**'
+      - 'templates/**'
+      - 'scripts/**'
+      - 'Taskfile.yml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm install
+      
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          version: 3.x
+      
+      - name: Generate OpenAPI documentation
+        run: task generate:openapi
+      
+      - name: Build documentation site
+        run: |
+          mkdir -p dist/docs
+          cp templates/swagger-ui.html dist/docs/index.html
+          # Copy OpenAPI files to be accessible
+          cp -r dist/openapi dist/docs/
+      
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: './dist/docs'
+      
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -155,6 +155,7 @@ tasks:
 
   docs:
     desc: Serve OpenAPI docs with Swagger UI (requires generate:openapi)
+    deps: [generate:openapi]
     cmds:
       - ./scripts/serve-docs.sh
 

--- a/scripts/convert-swagger-to-openapi.sh
+++ b/scripts/convert-swagger-to-openapi.sh
@@ -16,4 +16,29 @@ for swagger_file in dist/openapi/cyberstorm/attestor/v1/*.swagger.json; do
     fi
 done
 
+# Add server configurations to the OpenAPI specs
+echo "Adding server configurations..."
+for openapi_file in dist/openapi/cyberstorm/attestor/v1/*.openapi.json; do
+    if [ -f "$openapi_file" ]; then
+        echo "Adding servers to $(basename "$openapi_file")..."
+        # Use jq to add servers array after the info section
+        jq '. + {
+            "servers": [
+                {
+                    "url": "http://localhost:6001",
+                    "description": "Local development server"
+                },
+                {
+                    "url": "https://attestor.staging.cyberstorm.dev",
+                    "description": "Staging environment"
+                },
+                {
+                    "url": "https://attestor.cyberstorm.dev",
+                    "description": "Production environment"
+                }
+            ]
+        }' "$openapi_file" > "${openapi_file}.tmp" && mv "${openapi_file}.tmp" "$openapi_file"
+    fi
+done
+
 echo "✅ Swagger 2.0 to OpenAPI 3.0 conversion complete"

--- a/templates/swagger-ui.html
+++ b/templates/swagger-ui.html
@@ -27,27 +27,7 @@
           SwaggerUIBundle.plugins.DownloadUrl
         ],
         layout: "StandaloneLayout",
-        tryItOutEnabled: true,
-        // Configure servers for OpenAPI 3.0 after loading
-        onComplete: function() {
-          // Add server configurations - OpenAPI 3.0 supports multiple servers natively
-          ui.getSystem().specActions.updateSpec({
-            servers: [
-              {
-                url: 'http://localhost:6001',
-                description: 'Local development server'
-              },
-              {
-                url: 'https://attestor.staging.cyberstorm.dev',
-                description: 'Staging environment'
-              },
-              {
-                url: 'https://attestor.cyberstorm.dev',
-                description: 'Production environment'
-              }
-            ]
-          });
-        }
+        tryItOutEnabled: true
       });
     };
   </script>


### PR DESCRIPTION
## Summary
• Fixed Swagger UI server dropdown by adding servers directly to OpenAPI spec using jq in conversion script
• Simplified Swagger UI HTML by removing unreliable onComplete callback approach  
• Added GitHub Action workflow for deploying docs to GitHub Pages with manual trigger
• Added dependency to docs task in Taskfile to ensure OpenAPI generation runs first

## Test plan
- [ ] Run `task docs` and verify server dropdown appears at http://localhost:8080/docs/#/
- [ ] Test server selection between Local/Staging/Production endpoints
- [ ] Verify GitHub Pages deployment workflow can be triggered manually
- [ ] Confirm generated OpenAPI specs include servers section

🤖 Generated with [Claude Code](https://claude.ai/code)