### PR TITLE
fix(ci): update GitHub Pages workflow to use latest actions and manual trigger only

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,15 +1,7 @@
 name: Deploy Documentation to GitHub Pages
 
 on:
-  workflow_dispatch:  # Manual trigger
-  push:
-    branches:
-      - main
-    paths:
-      - 'schemas/**'
-      - 'templates/**'
-      - 'scripts/**'
-      - 'Taskfile.yml'
+  workflow_dispatch:  # Manual trigger only
 
 permissions:
   contents: read
@@ -64,10 +56,10 @@ jobs:
         uses: actions/configure-pages@v3
       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './dist/docs'
       
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
• Fixed deprecated GitHub Actions in deploy-docs workflow that was causing deployment failures
• Removed auto-trigger on push to main to prevent accidental deployments
• Updated to supported action versions for reliable GitHub Pages deployment

## Changes
- `upload-pages-artifact` v2 → v3 (fixes deprecation error)
- `deploy-pages` v2 → v4 (latest supported version)  
- Removed `push` trigger, keeping only `workflow_dispatch` for manual deployment

## Fixes
- Resolves deployment failure: "deprecated version of actions/upload-artifact: v3"
- Prevents unintended auto-deployments when pushing to main
- Ensures workflow uses only supported GitHub Actions versions

## Test plan
- [ ] Manually trigger workflow from Actions tab
- [ ] Verify deployment completes without deprecation errors
- [ ] Confirm docs are deployed to GitHub Pages successfully

🤖 Generated with [Claude Code](https://claude.ai/code)