### PR TITLE
fix(ci): update GitHub Pages workflow to use latest actions and manua…

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,15 +1,7 @@
 name: Deploy Documentation to GitHub Pages
 
 on:
-  workflow_dispatch:  # Manual trigger
-  push:
-    branches:
-      - main
-    paths:
-      - 'schemas/**'
-      - 'templates/**'
-      - 'scripts/**'
-      - 'Taskfile.yml'
+  workflow_dispatch:  # Manual trigger only
 
 permissions:
   contents: read
@@ -64,10 +56,10 @@ jobs:
         uses: actions/configure-pages@v3
       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './dist/docs'
       
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
…l trigger only

- Update upload-pages-artifact from v2 to v3 to fix deprecation error
- Update deploy-pages from v2 to v4 for compatibility
- Remove auto-trigger on push to main, keep manual workflow_dispatch only