### PR TITLE
fix: resolve OpenAPI path issue for GitHub Pages and license deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,13 @@ name = "cyberstorm-attestor-schemas"
 version = "1.0.0"
 description = "Protocol Buffer schemas and generated clients for Cyberstorm Attestor service"
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
 authors = [
     {name = "Allen Day", email = "allenday@users.github.com"}
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/templates/swagger-ui.html
+++ b/templates/swagger-ui.html
@@ -16,7 +16,7 @@
   <script>
     window.onload = function() {
       const ui = SwaggerUIBundle({
-        url: '../openapi/cyberstorm/attestor/v1/services.openapi.json',
+        url: './openapi/cyberstorm/attestor/v1/services.openapi.json',
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [


### PR DESCRIPTION
- Fix Swagger UI OpenAPI path from '../openapi/' to './openapi/' for GitHub Pages compatibility
- Update Python package license to modern SPDX format to resolve setuptools deprecation warnings