### PR TITLE
fix(ci): add missing buf CLI dependency to TypeScript generation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,7 +56,7 @@ tasks:
 
   generate:typescript:
     desc: Generate JavaScript clients using buf
-    deps: [clean, install:typescript]
+    deps: [clean, install, install:typescript]
     cmds:
       - buf generate --template buf.gen.typescript.yaml {{.SCHEMAS_DIR}} >logs/buf-typescript.log 2>&1
       - echo "JavaScript files generated in {{.DIST_DIR}}/typescript/"


### PR DESCRIPTION
## Summary
• Fixed release workflow failure by adding missing `install` dependency to `generate:typescript` task
• Resolves "exit status 127" (command not found) error in GitHub Actions
• Ensures buf CLI is properly installed before TypeScript generation

## Root Cause
The `generate:typescript` task had dependencies `[clean, install:typescript]` but was missing `install`, which installs the buf CLI. Other generation tasks (`generate:python`, `generate:go`) correctly included the `install` dependency.

When the release workflow runs in GitHub Actions, the buf CLI was not available during TypeScript generation, causing the build to fail with "command not found" error.

## Fix
- Changed `deps: [clean, install:typescript]` to `deps: [clean, install, install:typescript]`
- Now matches the dependency pattern used by other generation tasks
- Ensures buf CLI is installed before attempting to generate TypeScript clients

## Test Results
✅ `task package:all` now completes successfully locally  
✅ All generation tasks (TypeScript, Python, Go) work correctly  
✅ Ready for release workflow deployment

🤖 Generated with [Claude Code](https://claude.ai/code)