### PR TITLE
fix(ci): resolve check:all validation failure with parallel task structure

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,26 +56,30 @@ tasks:
 
   generate:typescript:
     desc: Generate JavaScript clients using buf
-    deps: [clean, install, install:typescript]
+    deps: [install, install:typescript]
     cmds:
+      - mkdir -p {{.DIST_DIR}}/typescript logs
       - buf generate --template buf.gen.typescript.yaml {{.SCHEMAS_DIR}} >logs/buf-typescript.log 2>&1
       - echo "JavaScript files generated in {{.DIST_DIR}}/typescript/"
 
   generate:python:
     desc: Generate Python clients  
-    deps: [clean, install]
+    deps: [install]
     cmds:
+      - mkdir -p {{.DIST_DIR}}/python logs
       - buf generate --template buf.gen.python.yaml {{.SCHEMAS_DIR}} >logs/buf-python.log 2>&1
       - echo "Python files generated in {{.DIST_DIR}}/python/"
 
   generate:go:
     desc: Generate Go clients
-    deps: [clean, install]  
+    deps: [install]  
     cmds:
+      - mkdir -p {{.DIST_DIR}}/go logs
       - buf generate --template buf.gen.go.yaml {{.SCHEMAS_DIR}} >logs/buf-go.log 2>&1
       - cp templates/go.mod.template {{.DIST_DIR}}/go/go.mod
       - |
-        if [ ! -f "go.mod" ]; then
+        if [ ! -f "{{.DIST_DIR}}/go/go.mod" ]; then
+          cd {{.DIST_DIR}}/go
           go mod init github.com/cyberstorm-dev/attestor-schemas
           go mod tidy
         fi
@@ -83,8 +87,9 @@ tasks:
 
   generate:openapi:
     desc: Generate OpenAPI/Swagger specs
-    deps: [clean, install]
+    deps: [install]
     cmds:
+      - mkdir -p {{.DIST_DIR}}/openapi {{.DIST_DIR}}/docs logs
       - buf generate --template buf.gen.openapi.yaml {{.SCHEMAS_DIR}} >logs/buf-openapi.log 2>&1
       - ./scripts/convert-swagger-to-openapi.sh
       - echo "Swagger 2.0 and OpenAPI 3.0 files generated in {{.DIST_DIR}}/openapi/"
@@ -119,12 +124,13 @@ tasks:
 
   install:python:
     desc: Install Python package in development mode
+    deps: [generate:python]
     cmds:
       - ./scripts/install-python.sh
 
   check:python:
     desc: Validate packaged Python package works
-    deps: [package:python, install:python]
+    deps: [package:python]
     cmds:
       - ./scripts/check-python.sh
 
@@ -145,6 +151,7 @@ tasks:
 
   check:all:
     desc: Run all generation checks
+    deps: [clean, install]
     cmds:
       - task: check:typescript
       - task: check:python
@@ -167,7 +174,7 @@ tasks:
 
   package:python:
     desc: Package Python for PyPI distribution
-    deps: [generate:python, install:python]
+    deps: [generate:python]
     cmds:
       - ./scripts/build-python.sh
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ Repository = "https://github.com/cyberstorm-dev/attestor-schemas.git"
 Issues = "https://github.com/cyberstorm-dev/attestor-schemas/issues"
 
 [tool.setuptools]
-packages = ["cyberstorm"]
+packages = ["cyberstorm", "cyberstorm.attestor", "cyberstorm.attestor.v1"]
 
 [tool.setuptools.package-dir]
 "" = "dist/python"


### PR DESCRIPTION
## Summary

Fixed the `check:all` validation failure by resolving race conditions and dependency conflicts in the Task orchestration system. Created parallel identical structures across all languages.

### Issues Resolved

- ✅ Fixed "context canceled" errors during Python generation
- ✅ Eliminated circular dependencies between tasks
- ✅ Fixed Python package not including subpackages 
- ✅ Resolved Go module path resolution issues
- ✅ Created clean parallel dependency structure for all languages

### Key Changes

**Python Package Configuration** (`pyproject.toml`):
- Updated packages to include all subpackages: `["cyberstorm", "cyberstorm.attestor", "cyberstorm.attestor.v1"]`
- Ensures all generated proto files are included in the wheel

**Task Dependency Restructure** (`Taskfile.yml`):
- Moved `clean` dependency to `check:all` level to eliminate race conditions
- Removed `clean` from individual `generate:*` tasks
- Added `mkdir -p` commands to ensure directories exist
- Fixed circular dependency: `install:python` → `generate:python` → `package:python`
- Fixed Go module path check in `generate:go` task

### Parallel Task Structure

All languages now follow identical dependency patterns:
```
check:typescript -> package:typescript -> generate:typescript -> [install, install:typescript]
check:python    -> package:python    -> generate:python    -> [install]  
check:go        -> package:go        -> generate:go        -> [install]
check:openapi   -> generate:openapi  -> [install]
```

### Test Results

✅ `task check:all` now passes successfully
✅ All four language targets (TypeScript, Python, Go, OpenAPI) validate correctly  
✅ Python packages properly include all proto-generated files
✅ Go modules build and verify successfully
✅ No more "context canceled" or race condition errors

🤖 Generated with [Claude Code](https://claude.ai/code)